### PR TITLE
Update AppInfo.cs

### DIFF
--- a/src/wp8/AppInfo.cs
+++ b/src/wp8/AppInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Xml.Linq;
 
 using WPCordovaClassLib.Cordova;
@@ -31,9 +32,8 @@ namespace Cordova.Extension.Commands
                 appInfo["version"] = manifestAppElement.Attribute("Version").Value;
             }
 
-            string jsonString = JsonHelper.Serialize(keys);
 
-            DispatchCommandResult(new PluginResult(PluginResult.Status.OK, jsonString));
+            DispatchCommandResult(new PluginResult(PluginResult.Status.OK, "{\"identifier\": \"" + appInfo["identifier"] + "\", \"version\":\"" + appInfo["version"] + "\"}"));
         }
 
         public void getVersion(string options)


### PR DESCRIPTION
In the previous version there is not "using System.Collections.Generic;" useful to use Dictionary.
At JsonHelper.Serialize(keys) the variable "keys" is not defined, so I change directly the value passed as jsonString.

This work on WP 8.1