### PR TITLE
Add browser platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
       "android",
       "ios",
       "wp8",
-      "windows"
+      "windows",
+      "browser"
     ]
   },
   "repository": {
@@ -23,7 +24,8 @@
     "ecosystem:cordova",
     "cordova-android",
     "cordova-ios",
-    "cordova-wp8"
+    "cordova-wp8",
+    "cordova-browser"
   ],
   "author": {
     "name": "Dan Michael O. Heggø",
@@ -41,6 +43,10 @@
     {
       "name": "Michele Belluco",
       "url": "https://github.com/vash15"
+    },
+    {
+      "name": "Yiorgis Gozadinos",
+      "url": "https://github.com/ggozad"
     }
   ],
   "license": "MIT",

--- a/plugin.xml
+++ b/plugin.xml
@@ -60,11 +60,22 @@
 
   <!-- Windows universal apps (Windows 8.1, Windows Phone 8.1, Windows 8.0) -->
   <platform name="windows">
-    
+
     <js-module src="src/windows/AppInfoProxy.js" name="AppInfoProxy">
       <runs />
     </js-module>
 
+  <!-- Browser platform -->
   </platform>
+
+    <platform name="browser">
+
+      <config-file target="config.xml" parent="/*">
+        <feature name="AppInfo">
+          <param name="browser-package" value="AppInfo" />
+        </feature>
+      </config-file>
+
+    </platform>
 
 </plugin>

--- a/www/appinfo.js
+++ b/www/appinfo.js
@@ -19,7 +19,7 @@ function appInfo() {
             me.identifier = info.identifier;
             me.build = info.build || 'unknown';
             channel.onAppInfoReady.fire();
-        },function(e) {           
+        },function(e) {
             console.log("[ERROR] Error initializing Cordova: " + e);
         });
     });
@@ -53,6 +53,21 @@ appInfo.prototype.getVersion = function(success, fail) {
  */
 appInfo.prototype.getIdentifier = function(success, fail){
     exec(success, fail, 'AppInfo', 'getIdentifier', []);
+}
+
+// Override for browser platform
+
+if (cordova.platformId==='browser') {
+    appInfo.prototype.getAppInfo = function (success, fail) {
+        success({identifier: '', version: ''})
+    }
+    appInfo.prototype.getVersion = function (success, fail) {
+        success('')
+    }
+    appInfo.prototype.getIdentifier = function(success, fail){
+        success('')
+    }
+
 }
 
 module.exports = new appInfo();


### PR DESCRIPTION
Hey this adds the browser platform to the plugin. For some reason new versions of cordova seem to choke for me when the browser platform is added expecting the getAppInfo command to be present even if not called. This adds support for the browser platform unfortunately returning no info whatsoever but avoiding to have to hack around it. 