### PR TITLE
Add timout to continue even if getAppInfo fails

### DIFF
--- a/www/appinfo.js
+++ b/www/appinfo.js
@@ -13,8 +13,11 @@ function appInfo() {
 
     var me = this;
 
+    var timeout = setTimeout(() => { channel.onAppInfoReady.fire(); }, 100);
+
     channel.onCordovaReady.subscribe(function() {
         me.getAppInfo(function(info) {
+            clearTimeout(timeout);
             me.version = info.version;
             me.identifier = info.identifier;
             me.build = info.build || 'unknown';


### PR DESCRIPTION
When binary code is missing exec trigger failFunction on Android but not on iOS. We use a timer to continue.